### PR TITLE
Improve python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tox
+.cache
+*.egg-info

--- a/case_conversion/__init__.py
+++ b/case_conversion/__init__.py
@@ -1,3 +1,5 @@
-from case_conversion import (
+from __future__ import absolute_import
+
+from .case_conversion import (
     camelcase, pascalcase, snakecase, dashcase, kebabcase, spinalcase,
     constcase, dotcase, separate_words, slashcase, backslashcase)

--- a/case_conversion/case_parse.py
+++ b/case_conversion/case_parse.py
@@ -1,8 +1,8 @@
 import regex
 import sys
 
-PYTHON = sys.version_info[0]
-if 3 == PYTHON:
+PYTHON2 = sys.version_info[0] < 3
+if not PYTHON2:
     xrange = range
     unicode = str
 

--- a/case_conversion/case_parse.py
+++ b/case_conversion/case_parse.py
@@ -4,6 +4,7 @@ import sys
 PYTHON = sys.version_info[0]
 if 3 == PYTHON:
     xrange = range
+    unicode = str
 
 
 def parse_case(var, detect_acronyms=True, acronyms=[], preserve_case=False):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
   name='case_conversion',
-  version='2.0.0',
+  version='2.0.1',
   packages=['case_conversion'],
   install_requires=['regex>=2016.2.25'],
   description='Convert between different types of cases (unicode supported)',

--- a/tests/case_conversion_test.py
+++ b/tests/case_conversion_test.py
@@ -224,11 +224,11 @@ CAPITAL_CASES = [
 
 
 def _expand_values(values):
-    return [item for sublist in [[(name + '2' + case, case, value, values[case]) for name, value in values.iteritems()] + [(case + '_empty', case, '', '')] for case in CASES] for item in sublist]  # nopep8
+    return [item for sublist in [[(name + '2' + case, case, value, values[case]) for name, value in values.items()] + [(case + '_empty', case, '', '')] for case in CASES] for item in sublist]  # nopep8
 
 
 def _expand_values_preserve(preserve_values, values):
-    return [item for sublist in [[(name + '2' + case, case, value, preserve_values[case][name if name in CAPITAL_CASES else 'default']) for name, value in values.iteritems()] + [(case + '_empty', case, '', '')] for case in CASES_PRESERVE] for item in sublist]  # nopep8
+    return [item for sublist in [[(name + '2' + case, case, value, preserve_values[case][name if name in CAPITAL_CASES else 'default']) for name, value in values.items()] + [(case + '_empty', case, '', '')] for case in CASES_PRESERVE] for item in sublist]  # nopep8
 
 
 class CaseConversionTest(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py35
+
+[testenv]
+commands =
+  nosetests {posargs:tests}
+deps =
+  nose
+  nose_parameterized


### PR DESCRIPTION
@AlejandroFrias This PR fixes some Python 3 incompatibilities:
- Some imports were implicitly being interpreted as relative imports on python 2. These are hard errors on python 3 under most circumstances, though the tests could still pass depending on your current directory.
- Use `.items()` instead of `.iteritems()`. Since these are only in tests, there's no performance issue, so the substitution is safe.
- Add a compatibility shim for `str/unicode`. I also made those shims [python 4 compatible](http://astrofrog.github.io/blog/2016/01/12/stop-writing-python-4-incompatible-code/).